### PR TITLE
Test suite for generic_file anon for Namur branch

### DIFF
--- a/e2e-tests/genericfile_anon_po.spec.js
+++ b/e2e-tests/genericfile_anon_po.spec.js
@@ -4,197 +4,199 @@ const { FilePage, StoreModal, docTypes } = require('./genericfile_po');
 let filePage;
 
 test.beforeEach(async ({ page, isMobile }, testInfo) => {
-   test.setTimeout(60000);
-   filePage = new FilePage(page, testInfo.title, isMobile);
+  test.setTimeout(60000);
+  filePage = new FilePage(page, testInfo.title, isMobile);
 });
 
 test.describe('New file modal', () => {
-    docTypes.forEach(function (name) {
-        test(`Explore new file modal from ${name}.`, async ({page, context}, testInfo) => {
-            try {
-                const fileType = name;
-                // directly load a pad page and fetch its id from the url
-                await filePage.loadFileType(fileType);
-                const firstPad = filePage.fileId();
+  docTypes.forEach(function (name) {
+    test(`Explore new file modal from ${name}.`, async ({ page, context }, testInfo) => {
+      try {
+        const fileType = name;
+        // directly load a pad page and fetch its id from the url
+        await filePage.loadFileType(fileType);
+        const firstPad = filePage.fileId();
 
-                // click File twice and the menu will appear and then disappear.
-                await filePage.filemenu().click();
-                await expect(filePage.newFile).toBeVisible();
-                await filePage.filemenu().click();
-                await expect(filePage.newFile).not.toBeVisible();
+        // click File twice and the menu will appear and then disappear.
+        await filePage.filemenu().click();
+        await expect(filePage.newFile).toBeVisible();
+        await filePage.filemenu().click();
+        await expect(filePage.newFile).not.toBeVisible();
 
-                // click File -> New to reach the new file modal dialog and close it immediately.
-                await filePage.filemenu().click();
-                const cancelledFileModal = await filePage.newFileClick();
-                await expect(cancelledFileModal.close).toBeVisible();
-                await cancelledFileModal.close.click();
-                await expect(cancelledFileModal.close).not.toBeVisible();
-                await expect(filePage.filemenu()).toBeVisible();
+        // click File -> New to reach the new file modal dialog and close it immediately.
+        await filePage.filemenu().click();
+        const cancelledFileModal = await filePage.newFileClick();
+        await expect(cancelledFileModal.close).toBeVisible();
+        await cancelledFileModal.close.click();
+        await expect(cancelledFileModal.close).not.toBeVisible();
+        await expect(filePage.filemenu()).toBeVisible();
 
-                // click File -> New to reach the new file modal dialog again.
-                await filePage.filemenu().click();
-                const newFileModal = await filePage.newFileClick();
-                await expect(newFileModal.close).toBeVisible();
+        // click File -> New to reach the new file modal dialog again.
+        await filePage.filemenu().click();
+        const newFileModal = await filePage.newFileClick();
+        await expect(newFileModal.close).toBeVisible();
 
-                // In the modal, click icon for file type to create a new one in a new browser tab.
-                const nextPadPage = await newFileModal.createFileOfType(context, fileType);
-                await expect(nextPadPage.filemenu()).toBeVisible();
-                // Ensure this is indeed a new pad, and not just the same we previously had.
-                const secondPad = nextPadPage.fileId();
-                expect(secondPad).not.toBe(firstPad);
+        // In the modal, click icon for file type to create a new one in a new browser tab.
+        const nextPadPage = await newFileModal.createFileOfType(context, fileType);
+        await expect(nextPadPage.filemenu()).toBeVisible();
+        // Ensure this is indeed a new pad, and not just the same we previously had.
+        const secondPad = nextPadPage.fileId();
+        expect(secondPad).not.toBe(firstPad);
 
-                await filePage.toSuccess("New file modal works");
-            } catch (e) {
-                await filePage.toFailure(e, "New file modal doesn't work");
-            }
-        });
-    })
-})
+        await filePage.toSuccess('New file modal works');
+      } catch (e) {
+        await filePage.toFailure(e, "New file modal doesn't work");
+      }
+    });
+  });
+});
 
 test.describe('Share modal', () => {
-    docTypes.forEach(function (name) {
-        test(`Explore share modal from ${name}.`, async ({page, context}, testInfo) => {
-            try {
-                const fileType = name;
-                await filePage.loadFileType(fileType);
-                const originalId = filePage.fileId();
+  docTypes.forEach(function (name) {
+    test(`Explore share modal from ${name}.`, async ({ page, context }, testInfo) => {
+      try {
+        const fileType = name;
+        await filePage.loadFileType(fileType);
+        const originalId = filePage.fileId();
 
-                const shareModal = await filePage.shareButtonClick();
-                // check that the link to be copied points to the file currently open
-                await shareModal.copyButton.click();
-                const actual = await shareModal.getLinkAfterCopy();
-                expect(actual).toBe(originalId);
-                expect(actual).toContain('edit');
+        const shareModal = await filePage.shareButtonClick();
+        // check that the link to be copied points to the file currently open
+        await shareModal.copyButton.click();
+        const actual = await shareModal.getLinkAfterCopy();
+        expect(actual).toBe(originalId);
+        expect(actual).toContain('edit');
 
-                // check that the link for viewing is different from the link for editing.
-                await filePage.shareButtonClick();
-                await shareModal.viewToggle(fileType).click();
-                await shareModal.copyButton.click();
-                const actualForViewing = await shareModal.getLinkAfterCopy();
-                expect(actualForViewing).not.toBe(originalId);
-                expect(actualForViewing).toContain('view');
+        // check that the link for viewing is different from the link for editing.
+        await filePage.shareButtonClick();
+        await shareModal.viewToggle(fileType).click();
+        await shareModal.copyButton.click();
+        const actualForViewing = await shareModal.getLinkAfterCopy();
+        expect(actualForViewing).not.toBe(originalId);
+        expect(actualForViewing).toContain('view');
 
-                // check that opening a link correctly opens a new browser tab
-                await filePage.shareButtonClick();
-                await shareModal.viewToggle(fileType).click();
-                const openedLinkPage = await shareModal.openLinkClick(context);
-                const openedFileId = openedLinkPage.fileId();
-                expect(openedFileId).not.toBe(originalId);
-                if (fileType !== "form") {
-                    await expect(openedLinkPage.filemenu()).toBeVisible();
-                    await expect(filePage.fileName).toContainText('(Read only)');
-                }
+        // check that opening a link correctly opens a new browser tab
+        await filePage.shareButtonClick();
+        await shareModal.viewToggle(fileType).click();
+        const openedLinkPage = await shareModal.openLinkClick(context);
+        const openedFileId = openedLinkPage.fileId();
+        expect(openedFileId).not.toBe(originalId);
+        if (fileType !== 'form') {
+          await expect(openedLinkPage.filemenu()).toBeVisible();
+          await expect(filePage.fileName).toContainText('(Read only)');
+        }
 
-                await filePage.toSuccess("Share modal works well");
-            } catch (e) {
-                await filePage.toFailure(e, "Share modal failed");
-            }
-        });
-    })
-})
+        await filePage.toSuccess('Share modal works well');
+      } catch (e) {
+        await filePage.toFailure(e, 'Share modal failed');
+      }
+    });
+  });
+});
 
 test.describe('Chat modal', () => {
-    docTypes.forEach(function (name) {
-        test(`Explore chat modal for ${name}`, async ({page, context}, testInfo) => {
-            try {
-                const fileType = name;
-                await filePage.loadFileType(fileType);
+  docTypes.forEach(function (docType) {
+    test(`Explore chat modal for ${docType}`, async ({ page, context }, testInfo) => {
+      try {
+        await filePage.loadFileType(docType);
 
-                // Warning about storage may overlap with chat modal. First dismiss it.
-                await (new StoreModal(filePage)).dismissButton.click();
+        // Warning about storage may overlap with chat modal. First dismiss it.
+        await (new StoreModal(filePage)).dismissButton.click();
 
-                // Click chat to display the chat modal
-                const chatModal = await filePage.chatButtonClick();
-                await expect(chatModal.chatInput).toBeVisible();
+        // Click chat to display the chat modal
+        const chatModal = await filePage.chatButtonClick();
+        await expect(chatModal.chatInput).toBeVisible();
 
-                // Enter a message.
-                const chatMessage = "This is a test message";
-                await chatModal.enterText(chatMessage);
+        // Enter a message.
+        const chatMessage = 'This is a test message';
+        await chatModal.enterText(chatMessage);
 
-                // Now a request for help appears in the corner overlapping with chat.
-                await filePage.dismissHelpRequest();
+        // Now a request for help appears in the corner overlapping with chat.
+        await filePage.dismissHelpRequest();
 
-                // With the popup gone we can verify the visibility of the message.
-                await expect(chatModal.chatPane).toHaveText(new RegExp('.*' + chatMessage));
+        // With the popup gone we can verify the visibility of the message.
+        await expect(chatModal.chatPane).toHaveText(new RegExp('.*' + chatMessage));
 
-                // Click chat again to dismiss the chat modal.
-                await filePage.chatButtonClick();
-                await expect(chatModal.chatInput).not.toBeVisible();
+        // Click chat again to dismiss the chat modal.
+        await filePage.chatButtonClick();
+        await expect(chatModal.chatInput).not.toBeVisible();
 
-                await filePage.toSuccess("Chat modal works well");
-            } catch (e) {
-                await filePage.toFailure(e, "Chat modal failed");
-            }
-        })
-    })
-})
+        await filePage.toSuccess('Chat modal works well');
+      } catch (e) {
+        await filePage.toFailure(e, 'Chat modal failed');
+      }
+    });
+  });
+});
 
 test.describe('Change title', () => {
-    docTypes.forEach(function (name) {
-        test(`Change title for ${name}`, async ({page, context}, testInfo) => {
-            try {
-                const fileType = name;
-                await filePage.loadFileType(fileType);
-                await expect(filePage.fileName).toBeVisible();
+  docTypes.forEach(function (docType) {
+    test(`Change title for ${docType}`, async ({ page, context }, testInfo) => {
+      try {
+        // Load a new document.
+        await filePage.loadFileType(docType);
+        await expect(filePage.fileName).toBeVisible();
 
-                const newName = fileType + "-" + Math.random();
-                await filePage.titleEditBox.click();
-                await filePage.titleInput.fill(newName);
-                await filePage.saveTitle.click();
-                await expect(filePage.fileName).toContainText(newName);
+        // Enter a new document name.
+        const newName = docType + '-' + Math.random();
+        await filePage.titleEditBox.click();
+        await filePage.titleInput.fill(newName);
 
-                await filePage.toSuccess("Change title well");
-            } catch (e) {
-                await filePage.toFailure(e, "Change title failed");
-            }
-        })
-    })
-})
+        // Save the changed document name.
+        await filePage.saveTitle.click();
+        await expect(filePage.fileName).toContainText(newName);
+
+        await filePage.toSuccess('Changing title succeeded');
+      } catch (e) {
+        await filePage.toFailure(e, 'Changing title failed');
+      }
+    });
+  });
+});
 
 test.describe('Save/Remove ', () => {
-    docTypes.forEach(function (name) {
-        test(`Save and remove for ${name}`, async ({page, context}, testInfo) => {
-            try {
-                const fileType = name;
-                await filePage.loadFileType(fileType);
-                await expect(filePage.fileName).toBeVisible();
+  docTypes.forEach(function (name) {
+    test(`Save and remove for ${name}`, async ({ page, context }, testInfo) => {
+      try {
+        const fileType = name;
+        await filePage.loadFileType(fileType);
+        await expect(filePage.fileName).toBeVisible();
 
-                // First try to trash without having saved, which should raise a warning.
-                await filePage.filemenu().click();
-                await filePage.trashFile.click();
-                await expect(filePage.mainFrame.getByText(
-                    "You must store this document in your CryptDrive before being able to use this feature."
-                )).toBeVisible();
-                await filePage.okButton.click();
+        // First try to trash without having saved, which should raise a warning.
+        await filePage.filemenu().click();
+        await filePage.trashFile.click();
+        await expect(filePage.mainFrame.getByText(
+          'You must store this document in your CryptDrive before being able to use this feature.'
+        )).toBeVisible();
+        await filePage.okButton.click();
 
-                // First store the document.
-                await filePage.filemenu().click();
-                await expect(filePage.storeFile).toBeVisible();
-                await filePage.storeFile.click();
-                await expect(filePage.mainFrame.getByText(
-                    "The document was successfully stored in your CryptDrive!"
-                )).toBeVisible();
+        // First store the document.
+        await filePage.filemenu().click();
+        await expect(filePage.storeFile).toBeVisible();
+        await filePage.storeFile.click();
+        await expect(filePage.mainFrame.getByText(
+          'The document was successfully stored in your CryptDrive!'
+        )).toBeVisible();
 
-                // Then trash the document, first canceling.
-                await filePage.filemenu().click();
-                await filePage.trashFile.click();
-                await expect(filePage.alertMessage).toContainText("Are you sure");
-                await filePage.cancelButton.click();
-                await expect(filePage.cancelButton).not.toBeVisible();
+        // Then trash the document, first canceling.
+        await filePage.filemenu().click();
+        await filePage.trashFile.click();
+        await expect(filePage.alertMessage).toContainText('Are you sure');
+        await filePage.cancelButton.click();
+        await expect(filePage.cancelButton).not.toBeVisible();
 
-                // Now try trashing again, but do it for real.
-                await filePage.filemenu().click();
-                await filePage.trashFile.click();
-                await expect(filePage.alertMessage).toContainText("Are you sure");
-                await filePage.okButton.click();
-                await expect(filePage.mainFrame.getByText('Deleted')).toBeVisible();
-                await filePage.okButton.click();
-                await expect(filePage.alertMessage).not.toBeVisible();
+        // Now try trashing again, but do it for real.
+        await filePage.filemenu().click();
+        await filePage.trashFile.click();
+        await expect(filePage.alertMessage).toContainText('Are you sure');
+        await filePage.okButton.click();
+        await expect(filePage.mainFrame.getByText('Deleted')).toBeVisible();
+        await filePage.okButton.click();
+        await expect(filePage.alertMessage).not.toBeVisible();
 
-                await filePage.toSuccess("Save/remove works well");
-            } catch (e) {
-                await filePage.toFailure(e, "Save/remove failed");
-            }
-       })
-    })
-})
+        await filePage.toSuccess('Save/remove works well');
+      } catch (e) {
+        await filePage.toFailure(e, 'Save/remove failed');
+      }
+    });
+  });
+});

--- a/e2e-tests/genericfile_anon_po.spec.js
+++ b/e2e-tests/genericfile_anon_po.spec.js
@@ -1,0 +1,200 @@
+const { test, expect } = require('@playwright/test');
+const { FilePage, StoreModal, docTypes } = require('./genericfile_po');
+
+let filePage;
+
+test.beforeEach(async ({ page, isMobile }, testInfo) => {
+   test.setTimeout(60000);
+   filePage = new FilePage(page, testInfo.title, isMobile);
+});
+
+test.describe('New file modal', () => {
+    docTypes.forEach(function (name) {
+        test(`Explore new file modal from ${name}.`, async ({page, context}, testInfo) => {
+            try {
+                const fileType = name;
+                // directly load a pad page and fetch its id from the url
+                await filePage.loadFileType(fileType);
+                const firstPad = filePage.fileId();
+
+                // click File twice and the menu will appear and then disappear.
+                await filePage.filemenu().click();
+                await expect(filePage.newFile).toBeVisible();
+                await filePage.filemenu().click();
+                await expect(filePage.newFile).not.toBeVisible();
+
+                // click File -> New to reach the new file modal dialog and close it immediately.
+                await filePage.filemenu().click();
+                const cancelledFileModal = await filePage.newFileClick();
+                await expect(cancelledFileModal.close).toBeVisible();
+                await cancelledFileModal.close.click();
+                await expect(cancelledFileModal.close).not.toBeVisible();
+                await expect(filePage.filemenu()).toBeVisible();
+
+                // click File -> New to reach the new file modal dialog again.
+                await filePage.filemenu().click();
+                const newFileModal = await filePage.newFileClick();
+                await expect(newFileModal.close).toBeVisible();
+
+                // In the modal, click icon for file type to create a new one in a new browser tab.
+                const nextPadPage = await newFileModal.createFileOfType(context, fileType);
+                await expect(nextPadPage.filemenu()).toBeVisible();
+                // Ensure this is indeed a new pad, and not just the same we previously had.
+                const secondPad = nextPadPage.fileId();
+                expect(secondPad).not.toBe(firstPad);
+
+                await filePage.toSuccess("New file modal works");
+            } catch (e) {
+                await filePage.toFailure(e, "New file modal doesn't work");
+            }
+        });
+    })
+})
+
+test.describe('Share modal', () => {
+    docTypes.forEach(function (name) {
+        test(`Explore share modal from ${name}.`, async ({page, context}, testInfo) => {
+            try {
+                const fileType = name;
+                await filePage.loadFileType(fileType);
+                const originalId = filePage.fileId();
+
+                const shareModal = await filePage.shareButtonClick();
+                // check that the link to be copied points to the file currently open
+                await shareModal.copyButton.click();
+                const actual = await shareModal.getLinkAfterCopy();
+                expect(actual).toBe(originalId);
+                expect(actual).toContain('edit');
+
+                // check that the link for viewing is different from the link for editing.
+                await filePage.shareButtonClick();
+                await shareModal.viewToggle(fileType).click();
+                await shareModal.copyButton.click();
+                const actualForViewing = await shareModal.getLinkAfterCopy();
+                expect(actualForViewing).not.toBe(originalId);
+                expect(actualForViewing).toContain('view');
+
+                // check that opening a link correctly opens a new browser tab
+                await filePage.shareButtonClick();
+                await shareModal.viewToggle(fileType).click();
+                const openedLinkPage = await shareModal.openLinkClick(context);
+                const openedFileId = openedLinkPage.fileId();
+                expect(openedFileId).not.toBe(originalId);
+                if (fileType !== "form") {
+                    await expect(openedLinkPage.filemenu()).toBeVisible();
+                    await expect(filePage.fileName).toContainText('(Read only)');
+                }
+
+                await filePage.toSuccess("Share modal works well");
+            } catch (e) {
+                await filePage.toFailure(e, "Share modal failed");
+            }
+        });
+    })
+})
+
+test.describe('Chat modal', () => {
+    docTypes.forEach(function (name) {
+        test(`Explore chat modal for ${name}`, async ({page, context}, testInfo) => {
+            try {
+                const fileType = name;
+                await filePage.loadFileType(fileType);
+
+                // Warning about storage may overlap with chat modal. First dismiss it.
+                await (new StoreModal(filePage)).dismissButton.click();
+
+                // Click chat to display the chat modal
+                const chatModal = await filePage.chatButtonClick();
+                await expect(chatModal.chatInput).toBeVisible();
+
+                // Enter a message.
+                const chatMessage = "This is a test message";
+                await chatModal.enterText(chatMessage);
+
+                // Now a request for help appears in the corner overlapping with chat.
+                await filePage.dismissHelpRequest();
+
+                // With the popup gone we can verify the visibility of the message.
+                await expect(chatModal.chatPane).toHaveText(new RegExp('.*' + chatMessage));
+
+                // Click chat again to dismiss the chat modal.
+                await filePage.chatButtonClick();
+                await expect(chatModal.chatInput).not.toBeVisible();
+
+                await filePage.toSuccess("Chat modal works well");
+            } catch (e) {
+                await filePage.toFailure(e, "Chat modal failed");
+            }
+        })
+    })
+})
+
+test.describe('Change title', () => {
+    docTypes.forEach(function (name) {
+        test(`Change title for ${name}`, async ({page, context}, testInfo) => {
+            try {
+                const fileType = name;
+                await filePage.loadFileType(fileType);
+                await expect(filePage.fileName).toBeVisible();
+
+                const newName = fileType + "-" + Math.random();
+                await filePage.titleEditBox.click();
+                await filePage.titleInput.fill(newName);
+                await filePage.saveTitle.click();
+                await expect(filePage.fileName).toContainText(newName);
+
+                await filePage.toSuccess("Change title well");
+            } catch (e) {
+                await filePage.toFailure(e, "Change title failed");
+            }
+        })
+    })
+})
+
+test.describe('Save/Remove ', () => {
+    docTypes.forEach(function (name) {
+        test(`Save and remove for ${name}`, async ({page, context}, testInfo) => {
+            try {
+                const fileType = name;
+                await filePage.loadFileType(fileType);
+                await expect(filePage.fileName).toBeVisible();
+
+                // First try to trash without having saved, which should raise a warning.
+                await filePage.filemenu().click();
+                await filePage.trashFile.click();
+                await expect(filePage.mainFrame.getByText(
+                    "You must store this document in your CryptDrive before being able to use this feature."
+                )).toBeVisible();
+                await filePage.okButton.click();
+
+                // First store the document.
+                await filePage.filemenu().click();
+                await expect(filePage.storeFile).toBeVisible();
+                await filePage.storeFile.click();
+                await expect(filePage.mainFrame.getByText(
+                    "The document was successfully stored in your CryptDrive!"
+                )).toBeVisible();
+
+                // Then trash the document, first canceling.
+                await filePage.filemenu().click();
+                await filePage.trashFile.click();
+                await expect(filePage.alertMessage).toContainText("Are you sure");
+                await filePage.cancelButton.click();
+                await expect(filePage.cancelButton).not.toBeVisible();
+
+                // Now try trashing again, but do it for real.
+                await filePage.filemenu().click();
+                await filePage.trashFile.click();
+                await expect(filePage.alertMessage).toContainText("Are you sure");
+                await filePage.okButton.click();
+                await expect(filePage.mainFrame.getByText('Deleted')).toBeVisible();
+                await filePage.okButton.click();
+                await expect(filePage.alertMessage).not.toBeVisible();
+
+                await filePage.toSuccess("Save/remove works well");
+            } catch (e) {
+                await filePage.toFailure(e, "Save/remove failed");
+            }
+       })
+    })
+})

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -25,7 +25,10 @@ class FilePage {
         this.storeFile = this.mainFrame.getByRole('menuitem', { name: 'Store' }).locator('a');
         this.trashFile = this.mainFrame.getByRole('menuitem', { name: 'Move to trash' }).locator('a');
         this.alertMessage = this.mainFrame.locator('.alertify').locator('.msg');
-        this.okButton = this.mainFrame.getByRole('button', { name: 'OK (enter)' });
+        this.okButton = this.mainFrame
+            .locator(".dialog")
+            .getByRole('button', { name: 'OK (enter)' })
+            .first();
         this.cancelButton = this.mainFrame.getByRole('button', { name: 'Cancel (esc)' });
         this.storageSuccess = this.mainFrame.locator('alertify-logs');
 

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -2,7 +2,6 @@
  * Page objects to support generic file test cases.
  */
 
-const { expect } = require('@playwright/test');
 const { url } = require("../fixture");
 const { FileActions } = require('./fileactions.js');
 
@@ -51,12 +50,12 @@ class FilePage {
 
     async loadFileType(fileType) {
         await this.page.goto(`${url}/${fileType}/`);
-        // loading a new file takes longer than the default timeout for expect calls.
-        await expect(this.filemenu()).toBeVisible({ timeout: 30_000 });
+        // loading a new file takes longer than the default timeout for expect calls,
+        // so we explicitly wait for it.
+        await this.filemenu().waitFor();
     }
 
     async newFileClick() {
-        await expect(this.newFile).toBeVisible();
         await this.newFile.click();
         return new NewFileModal(this);
     }
@@ -65,7 +64,6 @@ class FilePage {
         const mobLocator =
             this.mainFrame.locator('.cp-toolar-share-button');
         const shareLocator = this.mobile? mobLocator : this.shareButton;
-        await expect(shareLocator).toBeVisible();
         await shareLocator.click();
         return new ShareFileModal(this);
     }
@@ -80,7 +78,6 @@ class FilePage {
         const chatButton = this.mainFrame.getByRole('button', { name: 'Chat' });
         const chatLocator = this.mobile? mobLocator: chatButton;
 
-        await expect(chatLocator).toBeVisible();
         await chatLocator.click();
         return new ChatModal(this);
     }

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -48,7 +48,8 @@ class FilePage {
 
     async loadFileType(fileType) {
         await this.page.goto(`${url}/${fileType}/`);
-        await expect(this.filemenu()).toBeVisible();
+        // loading a new file takes longer than the default timeout for expect calls.
+        await expect(this.filemenu()).toBeVisible({ timeout: 30_000 });
     }
 
     async newFileClick() {

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -2,7 +2,7 @@
  * Page objects to support generic file test cases.
  */
 
-const { url } = require("../fixture");
+const { url } = require('../fixture');
 const { FileActions } = require('./fileactions.js');
 
 exports.docTypes = ['pad', 'sheet', 'code', 'slide', 'kanban', 'whiteboard', 'form', 'diagram'];
@@ -11,152 +11,151 @@ exports.docTypes = ['pad', 'sheet', 'code', 'slide', 'kanban', 'whiteboard', 'fo
  * A page object for a CryptPad file.
  */
 class FilePage {
+  constructor (page, testName, mobile) {
+    this.page = page;
+    this.testName = testName;
+    this.mobile = mobile;
+    this.fileActions = new FileActions(page);
 
-    constructor(page, testName, mobile) {
-        this.page = page;
-        this.testName = testName;
-        this.mobile = mobile;
-        this.fileActions = new FileActions(page);
+    // locators
+    this.mainFrame = page.frameLocator('#sbox-iframe');
+    this.newFile = this.mainFrame.getByRole('menuitem', { name: 'New' }).locator('a');
+    this.storeFile = this.mainFrame.getByRole('menuitem', { name: 'Store' }).locator('a');
+    this.trashFile = this.mainFrame.getByRole('menuitem', { name: 'Move to trash' }).locator('a');
+    this.alertMessage = this.mainFrame.locator('.alertify').locator('.msg');
+    this.okButton = this.mainFrame
+      .locator('.dialog')
+      .getByRole('button', { name: 'OK (enter)' })
+      .first();
+    this.cancelButton = this.mainFrame.getByRole('button', { name: 'Cancel (esc)' });
+    this.storageSuccess = this.mainFrame.locator('alertify-logs');
 
-        // locators
-        this.mainFrame = page.frameLocator('#sbox-iframe');
-        this.newFile = this.mainFrame.getByRole('menuitem', { name: 'New' }).locator('a');
-        this.storeFile = this.mainFrame.getByRole('menuitem', { name: 'Store' }).locator('a');
-        this.trashFile = this.mainFrame.getByRole('menuitem', { name: 'Move to trash' }).locator('a');
-        this.alertMessage = this.mainFrame.locator('.alertify').locator('.msg');
-        this.okButton = this.mainFrame
-            .locator(".dialog")
-            .getByRole('button', { name: 'OK (enter)' })
-            .first();
-        this.cancelButton = this.mainFrame.getByRole('button', { name: 'Cancel (esc)' });
-        this.storageSuccess = this.mainFrame.locator('alertify-logs');
+    this.shareButton = this.mainFrame.getByRole('button', { name: 'Share' });
 
-        this.shareButton  = this.mainFrame.getByRole('button', { name: 'Share' });
+    this.fileName = this.mainFrame.locator('.cp-toolbar-title');
+    this.titleEditBox = this.mainFrame.locator('.cp-toolbar-title-edit > .fa');
+    this.titleInput = this.mainFrame.locator('.cp-toolbar-title').locator('input');
+    this.saveTitle = this.mainFrame.locator('.cp-toolbar-title-save');
+  }
 
-        this.fileName = this.mainFrame.locator('.cp-toolbar-title');
-        this.titleEditBox = this.mainFrame.locator('.cp-toolbar-title-edit > .fa');
-        this.titleInput = this.mainFrame.locator('.cp-toolbar-title').locator('input');
-        this.saveTitle = this.mainFrame.locator('.cp-toolbar-title-save');
-    }
+  filemenu () {
+    return this.mobile ? this.fileActions.filemenuMobile : this.fileActions.filemenu;
+  }
 
-    filemenu() {
-        return this.mobile? this.fileActions.filemenuMobile : this.fileActions.filemenu;
-    }
+  // The last part of the URL gives the ID of a CryptPad file.
+  fileId () {
+    return this.page.url();
+  }
 
-    // The last part of the URL gives the ID of a CryptPad file.
-    fileId() {
-        return this.page.url();
-    }
+  async loadFileType (fileType) {
+    await this.page.goto(`${url}/${fileType}/`);
+    // loading a new file takes longer than the default timeout for expect calls,
+    // so we explicitly wait for it.
+    await this.filemenu().waitFor();
+  }
 
-    async loadFileType(fileType) {
-        await this.page.goto(`${url}/${fileType}/`);
-        // loading a new file takes longer than the default timeout for expect calls,
-        // so we explicitly wait for it.
-        await this.filemenu().waitFor();
-    }
+  async newFileClick () {
+    await this.newFile.click();
+    return new NewFileModal(this);
+  }
 
-    async newFileClick() {
-        await this.newFile.click();
-        return new NewFileModal(this);
-    }
+  async shareButtonClick () {
+    const mobLocator =
+      this.mainFrame.locator('.cp-toolar-share-button');
+    const shareLocator = this.mobile ? mobLocator : this.shareButton;
+    await shareLocator.click();
+    return new ShareFileModal(this);
+  }
 
-    async shareButtonClick() {
-        const mobLocator =
-            this.mainFrame.locator('.cp-toolar-share-button');
-        const shareLocator = this.mobile? mobLocator : this.shareButton;
-        await shareLocator.click();
-        return new ShareFileModal(this);
-    }
+  async dismissHelpRequest () {
+    const notNow = this.mainFrame.getByRole('button', { name: 'Not now', exact: true });
+    await notNow.click();
+  }
 
-    async dismissHelpRequest() {
-        const notNow = this.mainFrame.getByRole('button', { name: 'Not now', exact: true });
-        await notNow.click();
-    }
+  async chatButtonClick () {
+    const mobLocator = this.mainFrame.locator('#cp-toolbar-chat-drawer-open');
+    const chatButton = this.mainFrame.getByRole('button', { name: 'Chat' });
+    const chatLocator = this.mobile ? mobLocator : chatButton;
 
-    async chatButtonClick() {
-        const mobLocator = this.mainFrame.locator('#cp-toolbar-chat-drawer-open');
-        const chatButton = this.mainFrame.getByRole('button', { name: 'Chat' });
-        const chatLocator = this.mobile? mobLocator: chatButton;
+    await chatLocator.click();
+    return new ChatModal(this);
+  }
 
-        await chatLocator.click();
-        return new ChatModal(this);
-    }
+  async setStatus (status, reason) {
+    await this.page.evaluate(
+      _ => {
+      },
+      `browserstack_executor: ${JSON.stringify({
+        action: 'setSessionStatus',
+        arguments: {
+          name: this.testName,
+          status,
+          reason
+        }
+      })}`
+    );
+  }
 
-    async setStatus(status, reason) {
-        await this.page.evaluate(
-            _ => {},
-            `browserstack_executor: ${JSON.stringify({
-                action: 'setSessionStatus',
-                arguments: {
-                    name: this.testName,
-                    status: status,
-                    reason: reason
-                }
-            })}`
-        );
-    }
+  /**
+   * Marks the test as successful.
+   * @param reason
+   * @returns {Promise<void>}
+   */
+  async toSuccess (reason) {
+    await this.setStatus('passed', reason);
+  }
 
-    /**
-     * Marks the test as successful.
-     * @param reason
-     * @returns {Promise<void>}
-     */
-    async toSuccess(reason) {
-        await this.setStatus("passed", reason);
-    }
-
-    /**
-     * Marks the test as failed.
-     * @param exception
-     * @param reason
-     * @returns {Promise<void>}
-     */
-    async toFailure(exception, reason) {
-        console.log(exception);
-        await this.setStatus("failed", reason);
-        throw(exception);
-    }
+  /**
+   * Marks the test as failed.
+   * @param exception
+   * @param reason
+   * @returns {Promise<void>}
+   */
+  async toFailure (exception, reason) {
+    console.log(exception);
+    await this.setStatus('failed', reason);
+    throw exception;
+  }
 }
-
 
 /**
  * A page object for the modal that appears when creating a new file.
  */
 class NewFileModal {
-    constructor(filePage) {
-        this.filePage = filePage;
-        this.modalRoot = filePage.mainFrame.locator('#cp-app-toolbar-creation-dialog');
-        this.close = this.modalRoot.locator(".cp-modal-close");
-    }
+  constructor (filePage) {
+    this.filePage = filePage;
+    this.modalRoot = filePage.mainFrame.locator('#cp-app-toolbar-creation-dialog');
+    this.close = this.modalRoot.locator('.cp-modal-close');
+  }
 
-    async createFileOfType(context, fileType) {
-        // For new tabs, see https://playwright.dev/docs/pages#handling-new-pages
-        const pagePromise = context.waitForEvent('page');
-        await this.iconLocator(fileType).click();
-        const nextPage = await pagePromise;
-        return new FilePage(nextPage, this.filePage.testName, this.filePage.mobile);
-    }
+  async createFileOfType (context, fileType) {
+    // For new tabs, see https://playwright.dev/docs/pages#handling-new-pages
+    const pagePromise = context.waitForEvent('page');
+    await this.iconLocator(fileType).click();
+    const nextPage = await pagePromise;
+    return new FilePage(nextPage, this.filePage.testName, this.filePage.mobile);
+  }
 
-    iconLocator(fileType) {
-        return this
-            .filePage
-            .mainFrame
-            .getByText(
-                this.iconName(fileType),
-                { exact: true }
-            );
-    }
+  iconLocator (fileType) {
+    return this
+      .filePage
+      .mainFrame
+      .getByText(
+        this.iconName(fileType),
+        { exact: true }
+      );
+  }
 
-    iconName(fileType) {
-        switch(fileType) {
-            case 'pad':
-                return 'Rich text';
-            case 'slide':
-                return 'Markdown slides';
-            default:
-                return `${fileType.charAt(0).toUpperCase() + fileType.slice(1)}`;
-        }
+  iconName (fileType) {
+    switch (fileType) {
+      case 'pad':
+        return 'Rich text';
+      case 'slide':
+        return 'Markdown slides';
+      default:
+        return `${fileType.charAt(0).toUpperCase() + fileType.slice(1)}`;
     }
+  }
 }
 
 /**
@@ -169,58 +168,58 @@ class NewFileModal {
  * View only share links when opened should have the edit toggle disabled.
  */
 class ShareFileModal {
-    constructor(filePage) {
-        this.filePage = filePage;
-        this.shareFrame = filePage.page.frameLocator('#sbox-secure-iframe');
-        this.openButton = this.shareFrame.getByRole('button', { name: 'Open Link' });
-        this.copyButton = this.shareFrame.getByRole('button', { name: 'Copy Link' });
-    }
+  constructor (filePage) {
+    this.filePage = filePage;
+    this.shareFrame = filePage.page.frameLocator('#sbox-secure-iframe');
+    this.openButton = this.shareFrame.getByRole('button', { name: 'Open Link' });
+    this.copyButton = this.shareFrame.getByRole('button', { name: 'Copy Link' });
+  }
 
-    toggle(text) {
-        return this.shareFrame.getByText(text, { exact: true });
-    }
+  toggle (text) {
+    return this.shareFrame.getByText(text, { exact: true });
+  }
 
-    viewToggle(fileType) {
-        if (fileType === 'form') {
-            return this.toggle('Participant');
-        } else {
-            return this.toggle('View');
-        }
+  viewToggle (fileType) {
+    if (fileType === 'form') {
+      return this.toggle('Participant');
+    } else {
+      return this.toggle('View');
     }
+  }
 
-    async getLinkAfterCopy() {
-        return await this.filePage.page.evaluate('navigator.clipboard.readText()');
-    }
+  async getLinkAfterCopy () {
+    return await this.filePage.page.evaluate('navigator.clipboard.readText()');
+  }
 
-    async openLinkClick(context){
-        const pagePromise = context.waitForEvent('page');
-        await this.openButton.click();
-        const nextPage = await pagePromise;
-        return new FilePage(nextPage, this.filePage.testName, this.filePage.mobile);
-    }
+  async openLinkClick (context) {
+    const pagePromise = context.waitForEvent('page');
+    await this.openButton.click();
+    const nextPage = await pagePromise;
+    return new FilePage(nextPage, this.filePage.testName, this.filePage.mobile);
+  }
 }
 
 class ChatModal {
-    constructor(filePage) {
-        this.filePage = filePage;
-        this.chatPane = this.filePage.mainFrame.locator('.cp-app-contacts-chat');
-        this.chatInput = this.chatPane.getByPlaceholder('Type a message here...')
-    }
+  constructor (filePage) {
+    this.filePage = filePage;
+    this.chatPane = this.filePage.mainFrame.locator('.cp-app-contacts-chat');
+    this.chatInput = this.chatPane.getByPlaceholder('Type a message here...');
+  }
 
-    async enterText(text) {
-        await this.chatInput.click();
-        await this.chatInput.fill(text);
-        await this.chatInput.press('Enter');
-    }
+  async enterText (text) {
+    await this.chatInput.click();
+    await this.chatInput.fill(text);
+    await this.chatInput.press('Enter');
+  }
 }
 
 class StoreModal {
-    constructor(filePage) {
-        this.filePage = filePage;
-        this.storePane = this.filePage.mainFrame.locator('.cp-corner-container');
-        this.dismissButton = this.storePane.getByRole('button', { name: 'Don\'t store', exact: true });
-        this.storeButton = this.storePane.getByRole('button', { name: 'Store', exact: true });
-    }
+  constructor (filePage) {
+    this.filePage = filePage;
+    this.storePane = this.filePage.mainFrame.locator('.cp-corner-container');
+    this.dismissButton = this.storePane.getByRole('button', { name: 'Don\'t store', exact: true });
+    this.storeButton = this.storePane.getByRole('button', { name: 'Store', exact: true });
+  }
 }
 
 exports.FilePage = FilePage;

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -113,6 +113,7 @@ class FilePage {
     async toFailure(exception, reason) {
         console.log(exception);
         await this.setStatus("failed", reason);
+        throw(exception);
     }
 }
 

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -1,0 +1,225 @@
+/**
+ * Page objects to support generic file test cases.
+ */
+
+const { expect } = require('@playwright/test');
+const { url } = require("../fixture");
+const { FileActions } = require('./fileactions.js');
+
+exports.docTypes = ['pad', 'sheet', 'code', 'slide', 'kanban', 'whiteboard', 'form', 'diagram'];
+
+/**
+ * A page object for a CryptPad file.
+ */
+class FilePage {
+
+    constructor(page, testName, mobile) {
+        this.page = page;
+        this.testName = testName;
+        this.mobile = mobile;
+        this.fileActions = new FileActions(page);
+
+        // locators
+        this.mainFrame = page.frameLocator('#sbox-iframe');
+        this.newFile = this.mainFrame.getByRole('menuitem', { name: 'New' }).locator('a');
+        this.storeFile = this.mainFrame.getByRole('menuitem', { name: 'Store' }).locator('a');
+        this.trashFile = this.mainFrame.getByRole('menuitem', { name: 'Move to trash' }).locator('a');
+        this.alertMessage = this.mainFrame.locator('.alertify').locator('.msg');
+        this.okButton = this.mainFrame.getByRole('button', { name: 'OK (enter)' });
+        this.cancelButton = this.mainFrame.getByRole('button', { name: 'Cancel (esc)' });
+        this.storageSuccess = this.mainFrame.locator('alertify-logs');
+
+        this.shareButton  = this.mainFrame.getByRole('button', { name: 'Share' });
+
+        this.fileName = this.mainFrame.locator('.cp-toolbar-title');
+        this.titleEditBox = this.mainFrame.locator('.cp-toolbar-title-edit > .fa');
+        this.titleInput = this.mainFrame.locator('.cp-toolbar-title').locator('input');
+        this.saveTitle = this.mainFrame.locator('.cp-toolbar-title-save');
+    }
+
+    filemenu() {
+        return this.mobile? this.fileActions.filemenuMobile : this.fileActions.filemenu;
+    }
+
+    // The last part of the URL gives the ID of a CryptPad file.
+    fileId() {
+        return this.page.url();
+    }
+
+    async loadFileType(fileType) {
+        await this.page.goto(`${url}/${fileType}/`);
+        await expect(this.filemenu()).toBeVisible();
+    }
+
+    async newFileClick() {
+        await expect(this.newFile).toBeVisible();
+        await this.newFile.click();
+        return new NewFileModal(this);
+    }
+
+    async shareButtonClick() {
+        const mobLocator =
+            this.mainFrame.locator('.cp-toolar-share-button');
+        const shareLocator = this.mobile? mobLocator : this.shareButton;
+        await expect(shareLocator).toBeVisible();
+        await shareLocator.click();
+        return new ShareFileModal(this);
+    }
+
+    async dismissHelpRequest() {
+        const notNow = this.mainFrame.getByRole('button', { name: 'Not now', exact: true });
+        await notNow.click();
+    }
+
+    async chatButtonClick() {
+        const mobLocator = this.mainFrame.locator('#cp-toolbar-chat-drawer-open');
+        const chatButton = this.mainFrame.getByRole('button', { name: 'Chat' });
+        const chatLocator = this.mobile? mobLocator: chatButton;
+
+        await expect(chatLocator).toBeVisible();
+        await chatLocator.click();
+        return new ChatModal(this);
+    }
+
+    async setStatus(status, reason) {
+        await this.page.evaluate(
+            _ => {},
+            `browserstack_executor: ${JSON.stringify({
+                action: 'setSessionStatus',
+                arguments: {
+                    name: this.testName,
+                    status: status,
+                    reason: reason
+                }
+            })}`
+        );
+    }
+
+    /**
+     * Marks the test as successful.
+     * @param reason
+     * @returns {Promise<void>}
+     */
+    async toSuccess(reason) {
+        await this.setStatus("passed", reason);
+    }
+
+    /**
+     * Marks the test as failed.
+     * @param exception
+     * @param reason
+     * @returns {Promise<void>}
+     */
+    async toFailure(exception, reason) {
+        console.log(exception);
+        await this.setStatus("failed", reason);
+    }
+}
+
+
+/**
+ * A page object for the modal that appears when creating a new file.
+ */
+class NewFileModal {
+    constructor(filePage) {
+        this.filePage = filePage;
+        this.close = filePage.mainFrame.locator(".cp-modal-close");
+    }
+
+    async createFileOfType(context, fileType) {
+        // For new tabs, see https://playwright.dev/docs/pages#handling-new-pages
+        const pagePromise = context.waitForEvent('page');
+        await this.iconLocator(fileType).click();
+        const nextPage = await pagePromise;
+        return new FilePage(nextPage, this.filePage.testName, this.filePage.mobile);
+    }
+
+    iconLocator(fileType) {
+        console.log(this.iconName(fileType));
+        return this
+            .filePage
+            .mainFrame
+            .getByText(
+                this.iconName(fileType),
+                { exact: true }
+            );
+    }
+
+    iconName(fileType) {
+        switch(fileType) {
+            case 'pad':
+                return 'Rich text';
+            case 'slide':
+                return 'Markdown slides';
+            default:
+                return `${fileType.charAt(0).toUpperCase() + fileType.slice(1)}`;
+        }
+    }
+}
+
+/**
+ * A page object for the modal that appears when sharing a file.
+ *
+ * Modals for presentation and code have a 'present' toggle.
+ * Modals for forms have an auditor toggle, and don't have the standard view/edit toggles.
+ * Modals for pad, sheet, diagram and kanban have the same modal without extra toggles.
+ * Flipping the toggles changes the URL to be copied.
+ * View only share links when opened should have the edit toggle disabled.
+ */
+class ShareFileModal {
+    constructor(filePage) {
+        this.filePage = filePage;
+        this.shareFrame = filePage.page.frameLocator('#sbox-secure-iframe');
+        this.openButton = this.shareFrame.getByRole('button', { name: 'Open Link' });
+        this.copyButton = this.shareFrame.getByRole('button', { name: 'Copy Link' });
+    }
+
+    toggle(text) {
+        return this.shareFrame.getByText(text, { exact: true });
+    }
+
+    viewToggle(fileType) {
+        if (fileType === 'form') {
+            return this.toggle('Participant');
+        } else {
+            return this.toggle('View');
+        }
+    }
+
+    async getLinkAfterCopy() {
+        return await this.filePage.page.evaluate('navigator.clipboard.readText()');
+    }
+
+    async openLinkClick(context){
+        const pagePromise = context.waitForEvent('page');
+        await this.openButton.click();
+        const nextPage = await pagePromise;
+        return new FilePage(nextPage, this.filePage.testName, this.filePage.mobile);
+    }
+}
+
+class ChatModal {
+    constructor(filePage) {
+        this.filePage = filePage;
+        this.chatPane = this.filePage.mainFrame.locator('.cp-app-contacts-chat');
+        this.chatInput = this.chatPane.getByPlaceholder('Type a message here...')
+    }
+
+    async enterText(text) {
+        await this.chatInput.click();
+        await this.chatInput.fill(text);
+        await this.chatInput.press('Enter');
+    }
+}
+
+class StoreModal {
+    constructor(filePage) {
+        this.filePage = filePage;
+        this.storePane = this.filePage.mainFrame.locator('.cp-corner-container');
+        this.dismissButton = this.storePane.getByRole('button', { name: 'Don\'t store', exact: true });
+        this.storeButton = this.storePane.getByRole('button', { name: 'Store', exact: true });
+    }
+}
+
+exports.FilePage = FilePage;
+exports.StoreModal = StoreModal;

--- a/e2e-tests/genericfile_po.js
+++ b/e2e-tests/genericfile_po.js
@@ -125,7 +125,8 @@ class FilePage {
 class NewFileModal {
     constructor(filePage) {
         this.filePage = filePage;
-        this.close = filePage.mainFrame.locator(".cp-modal-close");
+        this.modalRoot = filePage.mainFrame.locator('#cp-app-toolbar-creation-dialog');
+        this.close = this.modalRoot.locator(".cp-modal-close");
     }
 
     async createFileOfType(context, fileType) {
@@ -137,7 +138,6 @@ class NewFileModal {
     }
 
     iconLocator(fileType) {
-        console.log(this.iconName(fileType));
         return this
             .filePage
             .mainFrame


### PR DESCRIPTION
This is a first contribution to the CryptPad E2E test suite from the Namur course on software testing (also described and discussed in https://github.com/cryptpad/e2e-test-suite/pull/6)

Future changes from this course can also propose a pull request for this `namur` branch, for example building on each other's page objects.

If relevant, the Cryptpad e2e team can cherry pick commits of interest, or request dedicated pull requests to the upstream e2e repository.