### PR TITLE
UML diagrams illustrating page objects

### DIFF
--- a/dev-docs/genericfile-class-diagram.puml
+++ b/dev-docs/genericfile-class-diagram.puml
@@ -1,0 +1,51 @@
+@startuml
+'https://plantuml.com/class-diagram
+scale 500 width
+
+title PageObjects for generic file operations
+
+class FilePage {
+    <<loc>> mainFrame
+    <<loc>> newFile
+    <<nav>> newFileClick (): NewFile
+    <<nav>> chatButtonClick(): Chat
+    <<nav>> shareButtonClick(): Share
+}
+
+FilePage <- NewFile: context
+
+class NewFile <<modal>> {
+    <<loc>> close
+    <<loc>> icon(type)
+    <<nav>> create(type): FilePage
+}
+
+Share --> FilePage: context
+
+class Share <<modal>> {
+    <<loc>> shareFrame
+    <<loc>> openButton
+    <<loc>> closeButton
+    <<loc>> copyButton
+    <<loc>> toggle(name)
+    <<nav>> openLink(): FilePage
+}
+
+Chat --> FilePage: context
+
+class Chat <<modal>> {
+    <<loc>> chatInput
+    <<mod>> enterText(text)
+}
+
+RootPage <|-- FilePage
+class "Playwright\nPage" as PWPage
+PWPage <- RootPage: page
+
+class RootPage {
+    toSuccess()
+    toFailure()
+}
+
+
+@enduml

--- a/dev-docs/genericfile-state-diagram.puml
+++ b/dev-docs/genericfile-state-diagram.puml
@@ -1,0 +1,31 @@
+@startuml
+'https://plantuml.com/state-diagram
+hide empty description
+scale 400 width
+
+title State diagram for\nnavigation from Cryptpad root
+
+note as N1
+Selected paths
+from the Cryptpad
+root.
+end note
+
+[*] -> Root
+
+Root --> PadFile : pad
+Root --> Drive: drive
+
+Drive --> NewFile: new
+
+PadFile --> PadFile: rename
+PadFile --> NewFile : new
+NewFile --> PadFile: pad
+
+PadFile --> Share: share
+Share --> PadFile: copy-\nlink
+
+Chat <- PadFile: chat
+Chat -> PadFile: close
+
+@enduml


### PR DESCRIPTION
A new folder with class and state diagrams in plantUML illustrating the design of the test cases for the genericfile test cases based on page objects.